### PR TITLE
feat: 메인페이지 추가 컴포넌트 및 404페이지 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import 'swiper/css/pagination';
 import Layout from '@/components/layout/Layout';
 import MainPage from '@/pages/MainPage';
 import StudyPage from '@/pages/StudyPage';
+import NotFound from './pages/NotFoundPage';
 
 function App() {
   return (
@@ -13,6 +14,7 @@ function App() {
         <Route element={<Layout />}>
           <Route path="/" element={<MainPage />} />
           <Route path="/study" element={<StudyPage />} />
+          <Route path="*" element={<NotFound />} />
         </Route>
       </Routes>
     </BrowserRouter>

--- a/src/components/sections/MainPage/Awards.tsx
+++ b/src/components/sections/MainPage/Awards.tsx
@@ -1,0 +1,87 @@
+import PillTab from "@/components/ui/PillTab";
+import { useState } from "react";
+
+export default function Awards() {
+    const awards = [{
+        tabIdx: 0,
+        year: 2019,
+        type: '장려상',
+        number: 1
+    }, {
+        tabIdx: 0,
+        year: 2020,
+        type: '동상',
+        number: 2
+    }, {
+        tabIdx: 1,
+        year: 2023,
+        type: '금상',
+        number: 1
+    },
+    {
+        tabIdx: 0,
+        year: 2019,
+        type: '장려상',
+        number: 1
+    }, {
+        tabIdx: 0,
+        year: 2020,
+        type: '동상',
+        number: 2
+    }, {
+        tabIdx: 1,
+        year: 2023,
+        type: '금상',
+        number: 1
+    },{
+        tabIdx: 0,
+        year: 2019,
+        type: '장려상',
+        number: 1
+    }, {
+        tabIdx: 0,
+        year: 2020,
+        type: '동상',
+        number: 2
+    }, {
+        tabIdx: 1,
+        year: 2023,
+        type: '금상',
+        number: 1
+    }, {
+        tabIdx: 1,
+        year: 2023,
+        type: '금상',
+        number: 1
+    }];
+
+    const [activeTabIdx, setActiveTabIdx] = useState<number>(0);
+
+    return (
+        <div className="w-full h-[120vh] flex flex-col items-center justify-evenly bg-[#EDEEFF]">
+            <div>
+                <p className="font-bold text-lg">각종 경진대회</p>
+                <h1 className="text-2xl font-bold">수상 이력</h1>
+            </div>
+
+            <div className="flex flex-col w-[80%] h-1/2 items-center justify-center gap-4">
+                <PillTab tabElements={[
+                    { label: 'shake!', active: activeTabIdx === 0 },
+                    { label: 'HEPC', active: activeTabIdx === 1 },
+                ]}  clickHandler={(index) => setActiveTabIdx(index)} activeTabIdx={activeTabIdx}/>
+
+
+                <div className="w-[80%] bg-[#DCDAEF] h-full rounded-lg grid grid-cols-3 gap-2 p-2 overflow-y-auto">
+                    {awards.filter((award) => award.tabIdx === activeTabIdx).map((award, index) => (
+                        <div key={index} className="flex flex-row items-center gap-2 p-1 bg-white rounded-lg">
+                            <span>{award.year}년</span>
+                            <span>{award.type}</span>
+                            <span>{award.number}회</span>
+                        </div>
+                    ))}
+                </div>
+            </div>
+            <p>위와 같은 수상 경험을 통해 알고리즘 문제 해결 능력을 입증하였으며 다양한 문제 유형을 분석하고 해결하는 과정에서 논리적 사고력과 실전 감각을 지속적으로 향상시켜 왔습니다.</p>
+        </div>
+    );
+}

--- a/src/components/sections/MainPage/CompetitionHistory.tsx
+++ b/src/components/sections/MainPage/CompetitionHistory.tsx
@@ -1,0 +1,11 @@
+export default function CompetitionHistory() {
+    return (
+        <div className="w-full h-[100vh] flex flex-col items-center justify-center p-4">
+            <p className="font-bold text-lg">자체 경진대회</p>
+            <h1 className="text-2xl font-bold mb-4">개최 이력</h1>
+            <div>HEPC</div>
+            <div>ZOAC</div>
+            <p className="w-[80%] text-center">학회에서는 알고리즘 및 프로그래밍 실력을 향상시키고 우수 인재를 발굴하기 위한 다양한 경진대회를 주최하고 있습니다. 이러한 경진대회는 참가자들에게 실력을 검증할 기회를 제공할 뿐만 아니라 학회 차원에서 프로그래밍 학습 문화와 경쟁력을 강화하는 데 기여하고 있습니다. 이를 통해 실전 경험을 쌓고 보다 심화된 문제 해결 능력을 배양할 수 있는 환경이 조성되고 있습니다.</p>
+        </div>
+    );
+}

--- a/src/components/ui/PillTab.tsx
+++ b/src/components/ui/PillTab.tsx
@@ -1,0 +1,11 @@
+export default function PillTab({tabElements, clickHandler, activeTabIdx}: { tabElements: { label: string, active: boolean }[], clickHandler: (index: number) => void, activeTabIdx: number }) {
+    return (
+        <div className="flex justify-evenly p-1 bg-[#DCDAEF] rounded-3xl gap-2">
+            {tabElements.map((element, index) => (
+                <div onClick={() => clickHandler(index)} key={index} className={`p-2 px-4 rounded-3xl hover:cursor-pointer ${activeTabIdx === index ? 'bg-white' : ''}`}>
+                    {element.label}
+                </div>
+            ))}
+        </div>
+    );
+}

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -1,4 +1,6 @@
+import Awards from '@/components/sections/MainPage/Awards';
 import ClubIntro from '@/components/sections/MainPage/ClubIntro';
+import CompetitionHistory from '@/components/sections/MainPage/CompetitionHistory';
 import Event from '@/components/sections/MainPage/Event';
 import Hero from '@/components/sections/MainPage/Hero';
 
@@ -8,9 +10,11 @@ export default function MainPage() {
       <div className="flex flex-col h-screen">
         <Hero />
       </div>
-      <div className="min-w-full flex flex-col items-center justify-center p-4 gap-10">
+      <div className="min-w-full flex flex-col items-center justify-center gap-10">
         <Event />
         <ClubIntro />
+        <Awards />
+        <CompetitionHistory />
       </div>
     </div>
   );

--- a/src/pages/NotFoundPage.tsx
+++ b/src/pages/NotFoundPage.tsx
@@ -1,0 +1,12 @@
+import zeroneCharacter from '@/assets/images/zerone_character.jpg';
+
+export default function NotFound(){
+    return (
+        <div className="w-full h-[100vh] flex flex-col items-center justify-center p-4">
+            <img src={zeroneCharacter} width={200} alt="" />
+            <h1 className="text-2xl font-bold mb-4">404 Not Found</h1>
+            <p className="text-center">죄송합니다, 요청하신 페이지를 찾을 수 없습니다.</p>
+            <p className="text-center">페이지가 삭제되었거나, URL이 잘못되었을 수 있습니다.</p>
+        </div>
+    );
+}


### PR DESCRIPTION
- Awards 컴포넌트: 필탭기반 수상이력 표시, css Grid로 3x2레이아웃 구성
- CompetitionHistory 컴포넌트: 자체 경진대회 개최이력 섹션 생성
- PillTab UI컴포넌트: 재사용 가능한 탭 컴포넌트 구현
- NotFoundPage: 404ㅔㅇ러 페이지 추가 및 라우팅 설정
- MainPage 레이아웃 개선: 패딩 조정으로 전체화면 활용

** 피그마에 추가된 페이지 뼈대 구현 완료했습니다.